### PR TITLE
返回逻辑错误内容时也要close body

### DIFF
--- a/client.go
+++ b/client.go
@@ -97,12 +97,12 @@ func execute(param Parameter) (bytes []byte, err error) {
 	if err != nil {
 		return
 	}
+	defer response.Body.Close()
 
 	if response.StatusCode != 200 {
 		err = fmt.Errorf("请求错误:%d", response.StatusCode)
 		return
 	}
-	defer response.Body.Close()
 	bytes, err = ioutil.ReadAll(response.Body)
 	return
 }


### PR DESCRIPTION
对于appkey, secrect key, session填错，权限不足等逻辑性的错误， 错误码非200， 也需要把body close，防止内存泄漏